### PR TITLE
Add board-nk3xn and board-nk3am features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 RUNNER := runners/lpc55
 
-build-dev:
-	make -C $(RUNNER) build-dev
+build:
+	make -C $(RUNNER) build
 
 bacon:
 	make -C $(RUNNER) bacon
 
-run-dev:
-	make -C $(RUNNER) run-dev
+run:
+	make -C $(RUNNER) run
 
 jlink:
 	scripts/bump-jlink

--- a/runners/lpc55/.gitignore
+++ b/runners/lpc55/.gitignore
@@ -2,3 +2,4 @@ target
 Cargo.lock
 *.elf
 lpc55s69.pack
+*.bin

--- a/runners/lpc55/Cargo.toml
+++ b/runners/lpc55/Cargo.toml
@@ -75,6 +75,8 @@ format-filesystem = []
 board-lpcxpresso55 = ["board/board-lpcxpresso55"]
 board-okdoe1 = ["board/board-okdoe1", "board-lpcxpresso55", "usbfs-peripheral"]
 board-solo2 = ["board/board-solo2"]
+board-nk3xn = ["board/board-nk3xn"]
+board-nk3am = ["board/board-nk3am", "board-solo2"]
 
 log-rtt = ["rtt-target"]
 log-semihosting = ["cortex-m-semihosting"]

--- a/runners/lpc55/Makefile
+++ b/runners/lpc55/Makefile
@@ -1,10 +1,31 @@
-FEATURES := board-lpcxpresso55,develop
+BOARD ?= nk3xn
 
-build-dev:
+FEATURES := board-${BOARD}
+
+ifeq "${DEVELOP}" "1"
+FEATURES := ${FEATURES},develop
+endif
+
+.PHONY: build
+build:
 	cargo build --release --features $(FEATURES)
 
-run-dev:
+.PHONY: run
+run:
 	cargo run --release --features $(FEATURES)
+
+.PHONY: objcopy
+objcopy:
+	cargo objcopy --release --features $(FEATURES) -- -O binary "firmware-${BOARD}.bin"
+
+.PHONY: flash
+flash: objcopy
+	mboot erase --mass
+	mboot write "firmware-${BOARD}.bin"
+
+.PHONY: size
+size:
+	cargo size --release --features $(FEATURES)
 
 bacon:
 	bacon

--- a/runners/lpc55/board/Cargo.toml
+++ b/runners/lpc55/board/Cargo.toml
@@ -15,6 +15,8 @@ trussed = { git = "https://github.com/trussed-dev/trussed", branch = "main" }
 board-lpcxpresso55 = []
 board-okdoe1 = ["board-lpcxpresso55"]
 board-solo2 = []
+board-nk3xn = []
+board-nk3am = ["board-solo2"]
 
 no-buttons = []
 no-clock-controller = []

--- a/runners/lpc55/board/README.md
+++ b/runners/lpc55/board/README.md
@@ -5,9 +5,11 @@ This implements `trussed::Platform` for some LPC55S69 boards.
 The main ones are:
 - [LPCXpresso55S69][lpcxpresso], the official development board by NXP
 - [Solo 2][solo2], the new security key by SoloKeys
+- NK3XN, the new [Nitrokey 3A NFC][nk3an] and [Nitrokey 3C NFC][nk3cn] devices
+- NK3AM, the new [Nitrokey 3A Mini][nk3am] device
 
-These can be selected via the features `board-lpcxpresso55` and `board-solo2`,
-respectively.
+These can be selected via the features `board-lpcxpresso55`, `board-solo2`,
+`board-nk3xn` and `board-nk3am`, respectively.
 
 It is more convenient to develop on the LPC55S69-EVK as it has `PIO0_5`, the `ISP0` pin, exposed.
 This allows forcing boot-to-bootloader, so you can't realy brick yourself until you start playing
@@ -35,3 +37,6 @@ Flashing firmware is *much* slower.
 [lpcxpresso]: https://www.nxp.com/design/development-boards/lpcxpresso-boards/lpcxpresso55s69-development-board:LPC55S69-EVK
 [okdoe1]: https://www.okdo.com/p/okdo-e1-development-board/
 [solo2]: https://solo2.dev
+[nk3an]: https://shop.nitrokey.com/shop/product/nk3an-nitrokey-3a-nfc-147
+[nk3cn]: https://shop.nitrokey.com/shop/product/nk3cn-nitrokey-3c-nfc-148
+[nk3am]: https://shop.nitrokey.com/shop/product/nk3am-nitrokey-3a-mini-149

--- a/runners/lpc55/board/src/lib.rs
+++ b/runners/lpc55/board/src/lib.rs
@@ -5,7 +5,7 @@ pub use lpc55_hal as hal;
 pub mod traits;
 
 // board support package
-#[cfg(not(any(feature = "board-lpcxpresso55", feature = "board-solo2")))]
+#[cfg(not(any(feature = "board-lpcxpresso55", feature = "board-solo2", feature = "board-nk3xn")))]
 compile_error!("Please select one of the board features.");
 
 #[cfg(feature = "board-lpcxpresso55")]
@@ -21,6 +21,11 @@ generate_macros!();
 pub mod solo2;
 #[cfg(feature = "board-solo2")]
 pub use solo2 as specifics;
+
+#[cfg(feature = "board-nk3xn")]
+pub mod nk3xn;
+#[cfg(feature = "board-nk3xn")]
+pub use nk3xn as specifics;
 
 pub use specifics::{
     button::ThreeButtons,

--- a/runners/lpc55/board/src/nk3xn.rs
+++ b/runners/lpc55/board/src/nk3xn.rs
@@ -1,0 +1,2 @@
+pub mod button;
+pub mod led;

--- a/runners/lpc55/board/src/nk3xn/button.rs
+++ b/runners/lpc55/board/src/nk3xn/button.rs
@@ -1,0 +1,195 @@
+use core::convert::Infallible;
+use crate::hal::traits::wg::digital::v2::InputPin;
+use crate::hal::traits::wg::timer::CountDown;
+use crate::hal::{
+    self,
+    drivers::pins,
+    typestates::pin,
+};
+use crate::hal::drivers::timer;
+use crate::hal::peripherals::{
+    ctimer,
+};
+use crate::traits::buttons::{
+    Button,State,
+    Press,Edge,
+};
+use crate::hal::typestates::{
+    init_state,
+};
+use hal::time::DurationExtensions;
+pub type UserButtonPin = pins::Pio0_31;
+// pub type WakeupButtonPin = pins::Pio1_18;
+pub type UserButton = hal::Pin<UserButtonPin, pin::state::Gpio<pin::gpio::direction::Input>>;
+// pub type WakeupButton = hal::Pin<WakeupButtonPin, pin::state::Gpio<pin::gpio::direction::Input>>;
+
+pub type ThreeButtons = XpressoButtons<ctimer::Ctimer1<init_state::Enabled>>;
+
+// type CtimerEnabled = ;
+// impl<P1,P2,P3, > TouchSensor<P1, P2, P3, >
+// where P1: PinId, P2: PinId, P3: PinId
+
+pub struct XpressoButtons <CTIMER>
+where CTIMER: ctimer::Ctimer<init_state::Enabled>
+{
+    last_state: State,
+    user_button: UserButton,
+    // wakeup_button: WakeupButton,
+    timer: timer::Timer<CTIMER>,
+}
+
+impl <CTIMER> XpressoButtons <CTIMER>
+where CTIMER: ctimer::Ctimer<init_state::Enabled>
+{
+    // pub fn new (timer: timer::Timer<CTIMER>, user_button: UserButton, wakeup_button: WakeupButton) -> XpressoButtons<CTIMER> {
+    pub fn new (timer: timer::Timer<CTIMER>, gpio: &mut hal::Gpio<hal::Enabled>, iocon: &mut hal::Iocon<hal::Enabled>) -> XpressoButtons<CTIMER> {
+        let user_button = UserButtonPin::take().unwrap().into_gpio_pin(iocon, gpio).into_input();
+        // let wakeup_button = WakeupButtonPin::take().unwrap().into_gpio_pin(iocon, gpio).into_input();
+        let buts = State {
+            a: user_button.is_high().ok().unwrap(),
+            b: user_button.is_high().ok().unwrap(),
+            middle: user_button.is_high().ok().unwrap(),
+        };
+        Self {
+            user_button: user_button,
+            // wakeup_button: wakeup_button,
+            last_state: buts,
+            timer: timer,
+        }
+    }
+}
+
+impl<CTIMER> Press for XpressoButtons <CTIMER>
+where CTIMER: ctimer::Ctimer<init_state::Enabled>
+{
+
+    // A minimal button implementation for Xpresso
+    fn is_pressed(&self, but: Button) -> bool {
+        match but {
+            Button::A=> {
+                self.user_button.is_low().ok().unwrap()
+            }
+            Button::B => {
+                self.user_button.is_low().ok().unwrap()
+            }
+            _ => {
+                self.user_button.is_low().ok().unwrap()
+            }
+        }
+    }
+
+}
+
+impl<CTIMER> XpressoButtons <CTIMER>
+where CTIMER: ctimer::Ctimer<init_state::Enabled>
+{
+    fn get_status_debounced(&mut self) -> State {
+        // first, remove jitter
+        let mut new_state = self.state();
+        self.timer.start(1_000.microseconds());
+        nb::block!(self.timer.wait()).ok();
+        let new_state2 = self.state();
+
+        if new_state.a != new_state2.a {
+            new_state.a = self.last_state.a;
+        }
+        if new_state.b != new_state2.b{
+            new_state.b = self.last_state.b;
+        }
+        if new_state.middle != new_state2.middle{
+            new_state.middle = self.last_state.middle;
+        }
+
+        new_state
+    }
+
+    fn read_button_edge(&mut self, but: Button, edge_type: bool) -> bool {
+
+        let new_state = self.get_status_debounced();
+
+        let mid_edge = (self.last_state.middle ^ new_state.middle) && (self.last_state.middle ^ edge_type);
+        let top_edge = (self.last_state.a ^ new_state.a) && (self.last_state.a ^ edge_type);
+        let bot_edge = (self.last_state.b ^ new_state.b) && (self.last_state.b ^ edge_type);
+
+        match but {
+            Button::A => {
+                self.last_state.a = new_state.a;
+                top_edge
+            }
+            Button::B => {
+                self.last_state.b = new_state.b;
+                bot_edge
+            }
+            Button::Middle => {
+                self.last_state.middle = new_state.middle;
+                mid_edge
+            }
+        }
+    }
+}
+
+impl<CTIMER> Edge for XpressoButtons <CTIMER>
+where CTIMER: ctimer::Ctimer<init_state::Enabled>
+{
+    /// Non-blockingly wait for the button to be pressed.
+    /// This is edge sensitive, meaning it will not complete successfully more than once
+    /// per actual button press.
+    /// Use block!(...) macro to actually block.
+    fn wait_for_new_press(&mut self, but: Button) -> nb::Result<(), Infallible> {
+        let result = self.read_button_edge(but, true);
+        if result {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    /// Same as for wait_for_press, but waits for the release of the button.
+    fn wait_for_new_release(&mut self, but: Button) -> nb::Result<(), Infallible> {
+        let result = self.read_button_edge(but, false);
+        if result {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    /// See wait_for_press
+    fn wait_for_any_new_press(&mut self, ) -> nb::Result<Button, Infallible> {
+        if self.read_button_edge(Button::A, true) {
+            Ok(Button::A)
+        } else if self.read_button_edge(Button::B, true) {
+            Ok(Button::B)
+        } else if self.read_button_edge(Button::Middle, true) {
+            Ok(Button::Middle)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    /// See wait_for_release
+    fn wait_for_any_new_release(&mut self, ) -> nb::Result<Button, Infallible> {
+        if self.read_button_edge(Button::A, false) {
+            Ok(Button::A)
+        } else if self.read_button_edge(Button::B, false) {
+            Ok(Button::B)
+        } else if self.read_button_edge(Button::Middle, false) {
+            Ok(Button::Middle)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn wait_for_new_squeeze(&mut self, ) -> nb::Result<(), Infallible> {
+        let oldstate = self.last_state;
+        let a = self.read_button_edge(Button::A, true);
+        let b = self.read_button_edge(Button::B, true);
+        if a && b {
+            Ok(())
+        } else {
+            if a { self.last_state.a = oldstate.a; }
+            if b { self.last_state.b = oldstate.b; }
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}

--- a/runners/lpc55/board/src/nk3xn/led.rs
+++ b/runners/lpc55/board/src/nk3xn/led.rs
@@ -1,0 +1,92 @@
+use crate::hal::{
+    self,
+    drivers::pins,
+    drivers::pwm,
+    peripherals::ctimer,
+    typestates::{
+        init_state,
+        pin::{
+            self,
+            function,
+        },
+    },
+    traits::wg::Pwm,
+    Iocon,
+};
+
+use crate::traits::rgb_led;
+
+
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+pub type RedLedPin = pins::Pio0_5;
+pub type GreenLedPin = pins::Pio1_21;
+pub type BlueLedPin = pins::Pio1_19;
+
+type RedLed = hal::Pin<
+    RedLedPin,
+    pin::state::Special<function::MATCH_OUTPUT0<ctimer::Ctimer3<init_state::Enabled>>>
+>;
+type GreenLed = hal::Pin<
+    GreenLedPin,
+    pin::state::Special<function::MATCH_OUTPUT2<ctimer::Ctimer3<init_state::Enabled>>>
+>;
+type BlueLed = hal::Pin<
+    BlueLedPin,
+    pin::state::Special<function::MATCH_OUTPUT1<ctimer::Ctimer3<init_state::Enabled>>>
+>;
+
+type PwmDriver = pwm::Pwm<ctimer::Ctimer3<init_state::Enabled>>;
+
+pub struct RgbLed {
+    pwm: PwmDriver,
+}
+
+impl RgbLed {
+    pub fn new(
+        mut pwm: PwmDriver,
+        iocon: &mut Iocon<init_state::Enabled>
+    ) -> RgbLed{
+
+        let red = RedLedPin::take().unwrap();
+        let green = GreenLedPin::take().unwrap();
+        let blue = BlueLedPin::take().unwrap();
+
+        pwm.set_duty(RedLed::CHANNEL,0);
+        pwm.set_duty(GreenLed::CHANNEL, 0);
+        pwm.set_duty(BlueLed::CHANNEL, 0);
+        pwm.enable(RedLed::CHANNEL);
+        pwm.enable(GreenLed::CHANNEL);
+        pwm.enable(BlueLed::CHANNEL);
+
+        // Don't set to output until after duty cycle is set to zero to save power.
+        red.into_match_output(iocon);
+        green.into_match_output(iocon);
+        blue.into_match_output(iocon);
+
+        pwm.scale_max_duty_by(8);
+
+        Self {
+            pwm,
+        }
+    }
+}
+
+impl rgb_led::RgbLed for RgbLed {
+    fn red(&mut self, intensity: u8){
+        self.pwm.set_duty(RedLed::CHANNEL, (intensity/2) as u16);
+    }
+
+    fn green(&mut self, intensity: u8){
+        self.pwm.set_duty(GreenLed::CHANNEL, (intensity as u16) * 3);
+    }
+
+    fn blue(&mut self, intensity: u8) {
+        self.pwm.set_duty(BlueLed::CHANNEL, (intensity as u16) * 8);
+    }
+}
+

--- a/runners/lpc55/src/lib.rs
+++ b/runners/lpc55/src/lib.rs
@@ -216,6 +216,13 @@ pub fn init_board(
         &mut iocon,
     );
 
+    #[cfg(feature = "board-nk3xn")]
+    let mut rgb = board::RgbLed::new(
+        Pwm::new(hal.ctimer.3.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap())),
+        &mut iocon,
+    );
+
+
     let (three_buttons,adc) = if is_passive_mode {
         (None, Some(adc))
     } else {
@@ -241,6 +248,13 @@ pub fn init_board(
                 &mut iocon,
             )
         };
+
+        #[cfg(feature = "board-nk3xn")]
+        let three_buttons = board::ThreeButtons::new(
+            Timer::new(hal.ctimer.1.enabled(&mut syscon, clocks.support_1mhz_fro_token().unwrap())),
+            &mut gpio,
+            &mut iocon,
+        );
 
         // Boot to bootrom if buttons are all held for 5s
         info!("button start {}",perf_timer.elapsed().0/1000);


### PR DESCRIPTION
This patch adds support for the NK3 protypes.  board-nk3xn can be used
for the NK3AN (= USB A NFC) and the NK3CN (= USB C NFC), and board-nk3am
can be used for the NK3AM (= USB A Mini).  Currently, board-nk3am is
only an alias for the board-solo2 feature as the solo2 code also works
for the NK3AM.

It also makes it easier to select a board when using the Makefile by
adding the BOARD variable, defaulting to nk3xn.